### PR TITLE
Add input and link AirTags

### DIFF
--- a/src/airdragon/__init__.py
+++ b/src/airdragon/__init__.py
@@ -15,4 +15,6 @@ from .tags import (
     H1 as H1,
     H2 as H2,
     H3 as H3,
+    Input as Input,
+    Link as Link,
 )

--- a/src/airdragon/tags.py
+++ b/src/airdragon/tags.py
@@ -178,3 +178,81 @@ class H2(DragonTag):
 
 class H3(DragonTag):
     class_ = "text-xl sm:text-2xl font-semibold leading-tight"
+
+
+class Input(DragonTagSelfClosing):
+    """A styled input field using BasecoatUI's input class.
+
+    Renders an <input> element with consistent styling for forms and search bars.
+
+    Args:
+        type: The input type (e.g., "text", "search", "email", "password").
+            Defaults to "text".
+        name: The form field name for submission.
+        id: The element's unique identifier.
+        placeholder: Hint text displayed when the input is empty.
+        value: The initial value of the input.
+        class_: Additional CSS classes to append to the default "input" class.
+        style: Inline CSS styles.
+        **kwargs: Additional HTML attributes (e.g., autofocus, required, disabled).
+
+    Example:
+        >>> ad.Input(type="search", name="q", placeholder="Search...")
+        <input type="search" name="q" placeholder="Search..." class="input"/>
+    """
+
+    class_ = "input"
+
+    def __init__(
+        self,
+        *,
+        type: str = "text",
+        name: str | None = None,
+        id: str | None = None,
+        placeholder: str | None = None,
+        value: str | None = None,
+        class_: str | None = None,
+        style: str | None = None,
+        **kwargs: AttributeType,
+    ) -> None:
+        super().__init__(**kwargs | locals_cleanup(locals()))
+
+    def render(self):
+        return f"""<input{self.attrs}/>"""
+
+
+class Link(DragonTag):
+    """A styled anchor link using BasecoatUI's link class.
+
+    Renders an <a> element with consistent styling for navigation and references.
+
+    Args:
+        *children: The link text or nested elements to display.
+        href: The URL the link points to (required).
+        class_: Additional CSS classes to append to the default "link" class.
+        id: The element's unique identifier.
+        style: Inline CSS styles.
+        target: Where to open the link (e.g., "_blank" for new tab).
+        **kwargs: Additional HTML attributes (e.g., rel, download, hx_get).
+
+    Example:
+        >>> ad.Link("Visit site", href="https://example.com", target="_blank")
+        <a href="https://example.com" target="_blank" class="link">Visit site</a>
+    """
+
+    class_ = "link"
+
+    def __init__(
+        self,
+        *children: Renderable,
+        href: str,
+        class_: str | None = None,
+        id: str | None = None,
+        style: str | None = None,
+        target: str | None = None,
+        **kwargs: AttributeType,
+    ) -> None:
+        super().__init__(*children, **kwargs | locals_cleanup(locals()))
+
+    def render(self) -> str:
+        return f"""<a{self.attrs}>{self.children}</a>"""

--- a/src/airdragon/tags.py
+++ b/src/airdragon/tags.py
@@ -184,6 +184,37 @@ class Input(DragonTagSelfClosing):
     """A styled input field using BasecoatUI's input class.
 
     Renders an <input> element with consistent styling for forms and search bars.
+    Automatically applies the "input" class - no need to specify Tailwind classes.
+
+    When to use:
+        Use ad.Input instead of air.Input when you want BasecoatUI styling
+        without manually adding class_="input".
+
+        # Without AirDragon (verbose):
+        air.Input(class_="input", type="email", placeholder="Email")
+
+        # With AirDragon (clean):
+        ad.Input(type="email", placeholder="Email")
+        # -> <input type="email" placeholder="Email" class="input"/>
+
+    Composition:
+        Typically used inside ad.Form or ad.Card with labels:
+
+        >>> ad.Form(
+        ...     air.Label("Email", for_="email"),
+        ...     ad.Input(id="email", type="email", placeholder="you@example.com"),
+        ...     ad.Button("Submit", type="submit"),
+        ... )
+
+        For search bars, combine with ad.Button in a fieldset:
+
+        >>> ad.Card(
+        ...     air.Fieldset(
+        ...         ad.Input(type="search", name="q", placeholder="Search..."),
+        ...         ad.Button("Search"),
+        ...         role="group",
+        ...     ),
+        ... )
 
     Args:
         type: The input type (e.g., "text", "search", "email", "password").
@@ -192,13 +223,23 @@ class Input(DragonTagSelfClosing):
         id: The element's unique identifier.
         placeholder: Hint text displayed when the input is empty.
         value: The initial value of the input.
-        class_: Additional CSS classes to append to the default "input" class.
+        class_: Additional CSS classes to append (not replace) the default
+            "input" class.
         style: Inline CSS styles.
-        **kwargs: Additional HTML attributes (e.g., autofocus, required, disabled).
+        **kwargs: Additional HTML attributes (e.g., autofocus, required,
+            disabled, hx_get, hx_trigger for HTMX).
 
     Example:
         >>> ad.Input(type="search", name="q", placeholder="Search...")
         <input type="search" name="q" placeholder="Search..." class="input"/>
+
+    Example with HTMX:
+        >>> ad.Input(
+        ...     type="search",
+        ...     name="q",
+        ...     hx_get="/search",
+        ...     hx_trigger="keyup changed delay:300ms",
+        ... )
     """
 
     class_ = "input"
@@ -225,19 +266,61 @@ class Link(DragonTag):
     """A styled anchor link using BasecoatUI's link class.
 
     Renders an <a> element with consistent styling for navigation and references.
+    Automatically applies the "link" class for BasecoatUI styling.
+
+    When to use:
+        Use ad.Link instead of air.A when you want BasecoatUI link styling
+        without manually adding class_="link".
+
+        # Without AirDragon (verbose):
+        air.A("Click here", href="/page", class_="link")
+
+        # With AirDragon (clean):
+        ad.Link("Click here", href="/page")
+        # -> <a href="/page" class="link">Click here</a>
+
+    Composition:
+        Works anywhere you need navigation. Common patterns:
+
+        Inside headings (e.g., for card titles):
+
+        >>> ad.Card(
+        ...     ad.H3(ad.Link("Article Title", href="/article/123")),
+        ...     air.P("Article description..."),
+        ... )
+
+        In navigation lists:
+
+        >>> air.Nav(
+        ...     air.Ul(
+        ...         air.Li(ad.Link("Home", href="/")),
+        ...         air.Li(ad.Link("About", href="/about")),
+        ...         air.Li(ad.Link("Contact", href="/contact")),
+        ...     ),
+        ... )
+
+        External links (open in new tab):
+
+        >>> ad.Link("View docs", href="https://docs.example.com", target="_blank")
 
     Args:
         *children: The link text or nested elements to display.
         href: The URL the link points to (required).
-        class_: Additional CSS classes to append to the default "link" class.
+        class_: Additional CSS classes to append (not replace) the default
+            "link" class.
         id: The element's unique identifier.
         style: Inline CSS styles.
         target: Where to open the link (e.g., "_blank" for new tab).
-        **kwargs: Additional HTML attributes (e.g., rel, download, hx_get).
+        **kwargs: Additional HTML attributes (e.g., rel="noopener" for security,
+            download for file downloads, hx_get for HTMX navigation).
 
     Example:
         >>> ad.Link("Visit site", href="https://example.com", target="_blank")
         <a href="https://example.com" target="_blank" class="link">Visit site</a>
+
+    Example with nested content:
+        >>> ad.Link(air.Strong("Important"), " link", href="/important")
+        <a href="/important" class="link"><strong>Important</strong> link</a>
     """
 
     class_ = "link"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -74,3 +74,26 @@ def test_H3():
         html
         == '<h3 class="text-xl sm:text-2xl font-semibold leading-tight">Subheading</h3>'
     )
+
+
+def test_Input():
+    html = ad.Input(placeholder="Search").render()
+    assert html == '<input type="text" placeholder="Search" class="input"/>'
+
+
+def test_Input_with_attrs():
+    html = ad.Input(type="search", name="q", id="search-box").render()
+    assert html == '<input type="search" name="q" id="search-box" class="input"/>'
+
+
+def test_Link():
+    html = ad.Link("Click here", href="https://example.com").render()
+    assert html == '<a href="https://example.com" class="link">Click here</a>'
+
+
+def test_Link_with_target():
+    html = ad.Link("External", href="https://example.com", target="_blank").render()
+    assert (
+        html
+        == '<a href="https://example.com" target="_blank" class="link">External</a>'
+    )


### PR DESCRIPTION
This pull request introduces two new styled components, `Input` and `Link`, to the AirDragon UI library, providing consistent BasecoatUI styling for input fields and anchor links. These components are added to the main package exports and are thoroughly documented and tested. The most important changes are:

**New Components:**

* Added `Input` component to `src/airdragon/tags.py`, providing a self-closing styled `<input>` element with automatic BasecoatUI "input" class and extensive documentation for usage and composition.
* Added `Link` component to `src/airdragon/tags.py`, providing a styled `<a>` element with automatic BasecoatUI "link" class and detailed usage documentation.

**Exports:**

* Exported `Input` and `Link` from `src/airdragon/__init__.py` for use throughout the package.

**Testing:**

* Added tests for `Input` and `Link` components in `tests/test_tags.py`, including rendering with various attributes and verifying correct HTML output.